### PR TITLE
Typo 'falg' -> 'flag'

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -25,7 +25,7 @@ Library trakeva
   Modules:    Trakeva, Trakeva_git_commands
 
 Library trakeva_sqlite
-  Build$: flag(sqlite) || flag(all) || falg(test)
+  Build$: flag(sqlite) || flag(all) || flag(test)
   Install$: flag(sqlite) || flag(all)
   Path:       src/lib_sqlite
   BuildTools: ocamlbuild


### PR DESCRIPTION
The short circuit of ||, ( I guess) does not trigger this when you do a `make configure`. But I somehow got this error when installing trakeva via opam. Although that was on 4.02, before I downgraded and the problem went away. I'm not going to untangle all the build dependencies of this, just noting that something weird happened.